### PR TITLE
change search fn to use post vs get http method

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,7 +306,7 @@ module.exports = function (options) {
       if (!indexName) throw new Error('indexName is not defined')
       if (!query) throw new Error('query is not defined')
 
-      get(['indexes', indexName, 'docs', query], null, function (err, results) {
+      post(['indexes', indexName, 'docs', 'search'], query, function (err, results) {
         if (err) return cb(err, null, results)
         if (results && results.error) return cb(results.error, null, results)
         cb(null, results.value, results)


### PR DESCRIPTION
I think it makes more sense to use post vs get when performing a search for two reasons:

1) [https://msdn.microsoft.com/en-us/library/azure/dn798927.aspx](https://msdn.microsoft.com/en-us/library/azure/dn798927.aspx)

"`When you use HTTP GET to call the Search API, you need to be aware that the length of the request URL cannot exceed 8 KB. This is usually enough for most applications. However, some applications produce very large queries or OData filter expressions. For these applications, using HTTP POST is a better choice because it allows larger filters and queries than GET. With POST, the number of terms or clauses in a query is the limiting factor, not the size of the raw query since the request size limit for POST is approximately 16 MB.`"

2) faceting doesn't seem to work because arrayToPath() returns multiple entries for facets. Your comment

"`// converts this ["hello","world", {format:"json", facet: ["a", "b"]}] into this "hello/world?format=json&facet=a&facet=b"`" while true doesn't seem to be supported by the search api. An error is thrown if "facet" is declared more than once.