### PR TITLE
update docs based on issue #18

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,7 +126,7 @@ client.count('myindex', function(err, count){
 });
 
 // search the index (note that multiple arguments can be passed as an array)
-client.search('myindex', {search: "document", $top: 10, facet: ["facet1", "facet2"]}, function(err, results){
+client.search('myindex', {search: "document", $top: 10, facets: ["facet1", "facet2"]}, function(err, results){
 	// optional error, or an array of matching results
 });
 

--- a/readme.md
+++ b/readme.md
@@ -126,7 +126,7 @@ client.count('myindex', function(err, count){
 });
 
 // search the index (note that multiple arguments can be passed as an array)
-client.search('myindex', {search: "document", $top: 10, facets: ["facet1", "facet2"]}, function(err, results){
+client.search('myindex', {search: "document", top: 10, facets: ["facet1", "facet2"]}, function(err, results){
 	// optional error, or an array of matching results
 });
 
@@ -228,7 +228,7 @@ i.e.
 
 ```js
 // search the index
-client.search('myindex', {search: "document", $top: 10}, function(err, results, raw){
+client.search('myindex', {search: "document", top: 10}, function(err, results, raw){
 	// raw argument contains response body as described here:
 	// https://msdn.microsoft.com/en-gb/library/azure/dn798927.aspx
 });


### PR DESCRIPTION
new post operation for search may have differing property names
```
{  
     "count": true | false (default),  
     "facets": [ "facet_expression_1", "facet_expression_2", ... ],  
     "filter": "odata_filter_expression",  
     "highlight": "highlight_field_1, highlight_field_2, ...",  
     "highlightPreTag": "pre_tag",  
     "highlightPostTag": "post_tag",  
     "minimumCoverage": # (% of index that must be covered to declare query successful; default 100),  
     "orderby": "orderby_expression",  
     "scoringParameters": [ "scoring_parameter_1", "scoring_parameter_2", ... ],  
     "scoringProfile": "scoring_profile_name",  
     "search": "simple_query_expression",  
     "searchFields": "field_name_1, field_name_2, ...",  
     "searchMode": "any" (default) | "all",  
     "select": "field_name_1, field_name_2, ...",  
     "skip": # (default 0),  
     "top": #  
}
```